### PR TITLE
exclude helm-related files from removal in gh-pages

### DIFF
--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -24,7 +24,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: gh-pages
-    - run: rm -rf *
+    # do not remove helm chart related files if present
+    - run: ls | grep -v -E "index.yaml|$(basename $(git rev-parse --show-toplevel))-.*\.tgz" | xargs rm -rf
     - uses: actions/download-artifact@v2
       with:
         name: book

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -25,7 +25,7 @@ jobs:
       with:
         ref: gh-pages
     # do not remove helm chart related files if present
-    - run: ls | grep -v -E "index.yaml|$(basename $(git rev-parse --show-toplevel))-.*\.tgz" | xargs rm -rf
+    - run: ls | grep -v -E "index.yaml|.*\.tgz" | xargs rm -rf
     - uses: actions/download-artifact@v2
       with:
         name: book


### PR DESCRIPTION
This PR excludes helm-related files from being deleted when running the mdbook publish action, to allow helm charts to be hosted in the same branch as documentation